### PR TITLE
Display errors when exception occurs.

### DIFF
--- a/app/Libraries/Utils.php
+++ b/app/Libraries/Utils.php
@@ -248,7 +248,9 @@ class Utils
                     $formattedValue = '<em>resource</em>';
                 } elseif (isset($item[1]) && ($item[1] instanceof \Closure))  {
                     $formattedValue = '<em>Closure</em>';
-                } elseif (isset($item[1]))  {
+		} elseif (isset($item[1]))  {
+                    if (isset($item[1]['exception_message']))
+                        echo $item[1]['exception_message']."\n";
                     $formattedValue = str_replace("\n", '', var_export(self::escapeHtml((string)$item[1]), true));
                 } else {
                     $formattedValue = "";


### PR DESCRIPTION
Just adding code to display the real `exception_message` when an exception occurs instead of generic `Array to string` error.

When I run `./artisan migrate` the error displayed is a generic one (snippet below):

```
app/Libraries/Utils.php(254): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8, 'Array to string...', '/home/shemgp/sr...', 254, Array)
```

I look at that line and see that $item[1] sometimes has an array.  Looked at the array and it has an `exception_message` entry, which is the real error.
