### PR TITLE
call to member function getname() on null

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -35,19 +35,20 @@ abstract class Controller extends BaseController
         $this->context = $context;
         $this->context_help_area = '';
 
-        if ( (new Setting())->get('app.context_help_area') ) {
-            try {
-                $routeName = $this->app->request->route()->getName();
-                $helpViewName = (($this->context) ? $this->context . "::" : '') . "context_help." . $routeName;
-                $this->context_help_area = View::make($helpViewName)->render();
+        if(!\App::runningInConsole()) {
+            if ( (new Setting())->get('app.context_help_area') ) {
+                try {
+                    $routeName = $this->app->request->route()->getName();
+                    $helpViewName = (($this->context) ? $this->context . "::" : '') . "context_help." . $routeName;
+                    $this->context_help_area = View::make($helpViewName)->render();
+                }
+                catch (\Exception $ex)
+                {
+                    $this->context_help_area = View::make('context_help.disabled', ['exMessage' => $ex->getMessage()])->render();
+                }
             }
-            catch (\Exception $ex)
-            {
-                $this->context_help_area = View::make('context_help.disabled', ['exMessage' => $ex->getMessage()])->render();
-            }
+            View::share('context_help_area', $this->context_help_area);
         }
-        View::share('context_help_area', $this->context_help_area);
     }
-
 
 }


### PR DESCRIPTION
Fix 'call to member function getname() on null' when listing routes with artisan.
